### PR TITLE
Update filters.cpp

### DIFF
--- a/opencv_gpb/src/gPb/filters.cpp
+++ b/opencv_gpb/src/gPb/filters.cpp
@@ -488,12 +488,12 @@ textonRun(const cv::Mat & input,
             output.at<float>(i,j)=temp.at<float>(i,j);
 }
 
-cv::Mat_<int>
+cv::Mat_<float>
 weight_matrix_disc(int r)
 {
     int size = 2*r + 1;
     int r_sq = r*r;
-    cv::Mat_<int> weights = cv::Mat_<int>::zeros(size, size);
+    cv::Mat_<float> weights = cv::Mat_<float>::zeros(size, size);
     for (int i = 0; i< weights.rows; i++)
         for (int j = 0; j< weights.cols; j++) {
             int x_sq = (i-r)*(i-r);
@@ -528,7 +528,7 @@ class ParallelInvokerUnit {
 private:
     double *oris_;
     int num_bins_;
-    cv::Mat_<int> weights_;
+    cv::Mat_<float> weights_;
     cv::Mat_<int> label_exp_;
     cv::Mat slice_map_;
     cv::Mat gaussian_kernel_;


### PR DESCRIPTION

In line 565 of filters.cpp, weights_ is an int type Mat_ object while weight_ptr_start is a float type pointer to first row of object weights_ which is a problem. As in  I tried with an example. Whenever value is 0 no problem but whenever it is 1 we have a problem. Following is an example : 

cv::Mat_<int>
weight_matrix_disc(int r)
{
    int size = 2*r + 1;
    int r_sq = r*r;
    cv::Mat_<int> weights = cv::Mat_<int>::zeros(size, size);
    for (int i = 0; i< weights.rows; i++)
        for (int j = 0; j< weights.cols; j++) {
            int x_sq = (i-r)*(i-r);
            int y_sq = (j-r)*(j-r);
            if ((x_sq + y_sq) <= r_sq)
                weights(i, j) = 1;
        }
    weights(r, r) = 0;
    return weights;
}


int main(int argc, char **argv){
Mat_<int> weights_;
weights_ = weight_matrix_disc(3);
float *weight_ptr_start = weights_.ptr < float > (0);
cout<<weight_ptr_start[3];
return 0;
}


Output : 1.4013e-45
Clearly a garbage value instead of 1.